### PR TITLE
isProjectComplete overrides all pending statuses

### DIFF
--- a/project-tracker-frontend/src/components/project-level-tracker.js
+++ b/project-tracker-frontend/src/components/project-level-tracker.js
@@ -7,6 +7,7 @@ import SampleLevelTracker from "./sample-level-tracker";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faAngleDown, faAngleRight, faFlask} from "@fortawesome/free-solid-svg-icons";
 
+// project: Project.js instance
 function ProjectLevelTracker({project}) {
     const [viewSamples, setViewSamples] = useState(false);
     const [showFailed, setShowFailed] = useState(true);
@@ -66,7 +67,7 @@ function ProjectLevelTracker({project}) {
         return <Col xs={12} sm={6}>
             <p className={"text-align-left"}><span className={"bold"}>Turn Around Time From Receiving</span>: {tatFromReceiving}</p>
         </Col>
-    }
+    };
 
     return <Container className={"border"}>
                     <Row className={"padding-vert-10 border"}>
@@ -84,7 +85,8 @@ function ProjectLevelTracker({project}) {
                         </Col>
                     </Row>
                     <Row className={"parent-sample-level-stages"}>
-                        <StageLevelTracker stages={stages}
+                        <StageLevelTracker isProjectComplete={project.getIgoComplete()}
+                                           stages={stages}
                                            orientation={"horizontal"}
                                            projectView={true}></StageLevelTracker>
                     </Row>
@@ -134,7 +136,8 @@ function ProjectLevelTracker({project}) {
                     </Row>
                     {
                         viewSamples ? <Row>
-                            <SampleLevelTracker samples={filteredSamples}></SampleLevelTracker>
+                            <SampleLevelTracker isProjectComplete={project.getIgoComplete()}
+                                                samples={filteredSamples}></SampleLevelTracker>
                         </Row> : <span></span>
                     }
 

--- a/project-tracker-frontend/src/components/project-tracker.js
+++ b/project-tracker-frontend/src/components/project-tracker.js
@@ -94,10 +94,6 @@ function ProjectTracker({projectName, projectState}) {
                     <h3 className={"position-bottom"}>{project ? project.getRecipe() : ''}</h3>
                 </Col>
                 <Col xs={3} md={2} className={"overflow-x-hidden"}>
-                    {
-                        (projectHasData(project) && project.getIgoComplete()) ? <FontAwesomeIcon className="request-complete" icon={faCheck}/>
-                            : <span></span>
-                    }
                     {getSummaryIcon(projectName)}
                 </Col>
             </Row>

--- a/project-tracker-frontend/src/components/sample-level-tracker.js
+++ b/project-tracker-frontend/src/components/sample-level-tracker.js
@@ -18,7 +18,15 @@ const translate = {
     x: 20
 };
 
-function SampleTree({sample, idx}){
+/**
+ *
+ * @param isProjectComplete - Is the project complete?
+ * @param sample
+ * @param idx
+ * @returns {*}
+ * @constructor
+ */
+function SampleTree({isProjectComplete, sample, idx}){
     const userSession = useSelector(state => state[STATE_USER_SESSION] );
     // TODO - constant
     const isUser = userSession['isUser'] || false;
@@ -69,7 +77,7 @@ function SampleTree({sample, idx}){
             </div>
         </Col>
         <Col xs={6} sm={7} md={9} className={"padding-vert-10 overflow-x-auto"}>
-            <StageLevelTracker label={sample['sampleId']}
+            <StageLevelTracker isProjectComplete={isProjectComplete}
                                stages={sample.stages}
                                orientation={"horizontal"}
                                projectView={false}></StageLevelTracker>
@@ -111,7 +119,14 @@ function SampleTree({sample, idx}){
     </Row>;
 }
 
-function SampleLevelTracker({samples}) {
+/**
+ *
+ * @param isProjectComplete - Is the project complete?
+ * @param samples
+ * @returns {*}
+ * @constructor
+ */
+function SampleLevelTracker({isProjectComplete, samples}) {
     return <Container>
         <Row>
             <Col xs={3} sm={2} md={1} className={"padding-vert-10 text-align-center"}>
@@ -126,7 +141,8 @@ function SampleLevelTracker({samples}) {
         </Row>
         {
             (samples.length > 0) ? samples.map((sample, idx) => {
-                return <SampleTree  sample={sample}
+                return <SampleTree  isProjectComplete={isProjectComplete}
+                                    sample={sample}
                                     idx={idx}
                                     key={`${sample}-${idx}`}></SampleTree>;
             }) :

--- a/project-tracker-frontend/src/components/stage-level-tracker.js
+++ b/project-tracker-frontend/src/components/stage-level-tracker.js
@@ -22,7 +22,16 @@ const getPendingIndex = (stages) => {
 };
 
 
-function StageLevelTracker({label, stages, orientation, projectView}) {
+/**
+ *
+ * @param isProjectComplete - Is the Project complete? This will override all view indications of pending status
+ * @param stages
+ * @param orientation
+ * @param projectView
+ * @returns {*}
+ * @constructor
+ */
+function StageLevelTracker({isProjectComplete, stages, orientation, projectView}) {
     const [pendingIndex, setPendingIndex] = useState(getPendingIndex(stages));     // Index of least-progressed step
     const [activeIndex, setActiveIndex] = useState(pendingIndex);       // Active state to show user
     const [labelSize, setLabelSize] = useState(projectView ? 0 : 2);
@@ -34,10 +43,10 @@ function StageLevelTracker({label, stages, orientation, projectView}) {
      * @returns {boolean}
      */
     const showStepIsCompleted = (stepIdx) => {
-        return stepIdx < pendingIndex
+        return (stepIdx < pendingIndex) || isProjectComplete;
     };
 
-    const generateStageSummary = (stage) => {
+    const generateStageSummary = (stage, isStageComplete) => {
         const stageName = stage['stage'] || '';
 
         // TODO - Submitted is often inconsistent w/ its number of samples
@@ -63,7 +72,7 @@ function StageLevelTracker({label, stages, orientation, projectView}) {
         // Renders the updated field
         const updateSpan = (stage) => {
             let updateField = 'Updated';
-            if(stage.complete){
+            if(isStageComplete){
                 updateField = 'Completed';
             }
             if(stage.updateTime === null || stage.updateTime === undefined) {
@@ -91,7 +100,7 @@ function StageLevelTracker({label, stages, orientation, projectView}) {
         */
 
         return <span>
-            { stage.complete ? <FontAwesomeIcon className="stage-tracker-icon success-green" icon={ faCheck }/>
+            { isStageComplete ? <FontAwesomeIcon className="stage-tracker-icon success-green" icon={ faCheck }/>
                 : <FontAwesomeIcon className="stage-tracker-icon update-blue" icon={ faEllipsisH }/> }
             <p><span className={"underline"}>
                 Progress</span>: {progressCount}/{total}
@@ -105,13 +114,13 @@ function StageLevelTracker({label, stages, orientation, projectView}) {
             <Col xs={12-labelSize}>
                 <Stepper activeStep={activeIndex} orientation={orientation}>
                     {stages.map((stage, index) => {
-                        const isCompleted = showStepIsCompleted(index);
+                        const isStageComplete = showStepIsCompleted(index);
                         const stageProps = {
-                            completed: isCompleted
+                            completed: isStageComplete
                         };
                         const labelProps = {};
                         if(projectView){
-                            labelProps.optional = generateStageSummary(stage);
+                            labelProps.optional = generateStageSummary(stage, isStageComplete);
                         };
                         const name = stage.stage;
                         return (

--- a/project-tracker-frontend/src/utils/Project.js
+++ b/project-tracker-frontend/src/utils/Project.js
@@ -38,7 +38,8 @@ class Project {
      * @returns {*|boolean}
      */
     getIgoComplete() {
-        return this.#igoComplete || false;
+        const summary = this.#summary || {};
+        return summary['isIgoComplete'] || false;
     }
 
     /**


### PR DESCRIPTION
The view for the project-tracker should show completed status for all stages at the project & sample level IF the project has been IGO complete.

Currently, if there is a pending step, this will not be the case.