### PR TITLE
User request filtering by groups

### DIFF
--- a/project-tracker-backend/helpers/utility.js
+++ b/project-tracker-backend/helpers/utility.js
@@ -1,9 +1,8 @@
 const jwtInCookie = require("jwt-in-cookie");
 const { logger } = require("../helpers/winston");
 
-// Fields in the ldap response that will be used to filter projects on
-const HIERARCHY_FILTERS = ["sn", "givenName"];
-const HIERARCHY_TARGETS = ["investigator", "pi"];
+// TODO - Remove Spring 2021 (all requests from past year should have AccessEmail fields
+const MISSING_ACCESS_GROUPS = new Set();
 
 /**
  * Retrieves isUser from the request cookie and returns value of isUser
@@ -31,49 +30,117 @@ exports.isUser = (req) => {
  *
  * @param data, [] - Array of project objects
  */
-exports.filterProjectsOnHierarchy = async (req, projects) => {
-	const filteredProjects = [];
+exports.filterProjectsOnHierarchy = async (apiReq, requests) => {
+	const userData = jwtInCookie.validateJwtToken(apiReq);
+    const userName = userData["username"];
+    const visibilityGroups = createVisibilityGroupsFromUserData(userData);
 
-	const userData = jwtInCookie.validateJwtToken(req);
-	const userName = userData["username"];
-
-	const HIERARCHY_KEY = "hierarchy";
-	let hierarchy = [];
-	if ( HIERARCHY_KEY in userData ){
-		hierarchy = userData[HIERARCHY_KEY] || [];
-	} else {
-		logger.error(`User ${userName}'s cookie didn't contain ${HIERARCHY_KEY}. All requests will be filtered out.`);
-	}
-
-	// usersWithVisibility: [ [ LAST_NAME, FIRST_NAME ], ... ]
-	const usersWithVisibility = hierarchy.map(hierarchyObject =>
-		// hierarchyObject: { sn: Franklin, givenName: Rosalind }
-		HIERARCHY_FILTERS.map(field => hierarchyObject[field])
-	);
-	logger.info( `Filtering visible projects for user: '${userName}' w/ representatives: ${(usersWithVisibility)}`);
-
-	for(const project of projects){
-		const projectRepresentatives = HIERARCHY_TARGETS.map(field => project[field]).filter(rep => rep !== undefined);
-		let hasProjectRepresentative = false;
-		for(const pr of projectRepresentatives){
-
-			// Search for one manager who is a project representative in one of the @HIERARCHY_TARGETS fields
-			const containsNames = usersWithVisibility.reduce((containsName, names) => {
-				for(const name of names){
-					if(!pr.includes(name)){
-						// Manager is not the project representative, return the result of previous
-						return containsName;
-					}
-				}
-				// At least one manager is a project representative and user should see the project
-				return true;
-			}, false);
-			hasProjectRepresentative = hasProjectRepresentative || containsNames
+    // Add all requests w/ at least one @accessGroups present in the visibilityGroups for user
+    let accessGroups, reqId;
+    const filteredRequests = [];
+	for(const request of requests){
+        accessGroups = getAccessGroups(request);
+        reqId = request["requestId"];
+        // TODO - Remove Spring 2021 (all requests from past year should have AccessEmail fields
+		if(accessGroups.length === 0){
+		    if(!MISSING_ACCESS_GROUPS.has(reqId)){
+		        MISSING_ACCESS_GROUPS.add(reqId);
+		        logger.error(`Request (Id: ${reqId}) is missing access groups and cannot be filtered`);
+		    }
+		} else {
+            logger.info(`Request (${reqId}) Access Groups: ${accessGroups.join(",")}`);
 		}
-		if(hasProjectRepresentative){
-			filteredProjects.push(project);
+		if(userHasAccessGroup(accessGroups, visibilityGroups)){
+			filteredRequests.push(request);
 		}
 	}
-	logger.info(`User: ${userName} should see ${filteredProjects.length} projects: ${filteredProjects.map(prj => prj["requestId"])}`);
-	return filteredProjects;
+	logger.info(`User: ${userName} should see ${filteredRequests.length} requests: ${filteredRequests.map(prj => prj["requestId"])}`);
+	return filteredRequests;
 };
+
+/**
+ * Parses out LDAP groups from cookie's userData
+ *
+ * @param userData - { ..., "groups": [ "CN=...,CN=..." ], ... }
+ */
+const parseGroups = (userData) => {
+    const groupsValue = userData["groups"] || "";
+    const cnGroups = groupsValue.split(",");
+    const groups = [];
+    for(const cnGroup of cnGroups){
+        const groupSplit = cnGroup.split("CN=");
+        if(groupSplit.length === 2){
+            groups.push( groupSplit[1] );
+        }
+    }
+    return groups;
+}
+
+/**
+ * Parses and formats AccessEmail fields from request object
+ *
+ * @param userData - { ..., dataAccessEmails: "user@ski.mskcc.org", ..., qcAccessEmail: "user@mskcc.org", ... }
+ */
+const getAccessGroups = (request) => {
+    const dataAccessEmailsValue = request['dataAccessEmails'] || "";
+    const qcAccessEmailsValue = request['qcAccessEmail'] || "";
+
+    const dataAccessEmails = dataAccessEmailsValue.split(",");
+    const qcAccessEmails = qcAccessEmailsValue.split(",");
+
+    const accessEmails = dataAccessEmails.concat(qcAccessEmails);
+    const accessGroups = [];
+    for(const email of accessEmails){
+        let accessGroup;
+        if( email.includes("@ski.mskcc.org") ){
+            // Legacy email format: {FIRST_INITIAL}-{LAST_NAME}@ski.mskcc.org
+            const user = email.split("@ski.mskcc.org")[0];
+            const firstInitial = user.substring(0,1);
+            const lastName = user.substring(2,user.length);
+            accessGroup = `${lastName}${firstInitial}`;
+        } else if ( email.includes("@mskcc.org") ) {
+            accessGroup = email.split("@mskcc.org")[0];
+        } else {
+            if(email !== ""){
+                logger.error(`Could not parse accessGroup from email: ${email}`);
+            }
+            continue;
+        }
+        accessGroups.push(accessGroup);
+    }
+
+    return accessGroups;
+}
+
+/**
+ * Returns a set of LDAP groups for a user
+ *
+ * @param userData - { ..., "groups": [ "CN=...,CN=..." ], "username": "user", ... }
+ */
+const createVisibilityGroupsFromUserData = (userData) => {
+	const groups = parseGroups(userData);
+    const userName = userData["username"];
+    const visibilityGroups = new Set(groups);
+    visibilityGroups.add(userName);
+    logger.info(`Filtering requests w/ following groups: ${[... visibilityGroups].join(",")}`);
+
+    return visibilityGroups;
+}
+
+/**
+ * Checks if the given accessGroups are present in the set of groups of the visibilityGroups
+ *    e.g.  accessGroups: [ "u1" ], visibilityGroups: { "u1" }   ->      true
+ *          accessGroups: [ "u2" ], visibilityGroups: { "u1" }   ->      false
+ *
+ * @param accessGroups - List of LDAP groups being checked for membership
+ * @param visibilityGroups - set of LDAP groups being checked against
+ */
+const userHasAccessGroup = (accessGroups, visibilityGroups) => {
+    for(const accessGroup of accessGroups){
+        if(visibilityGroups.has(accessGroup)){
+            return true;
+        }
+    }
+    return false;
+}
+

--- a/project-tracker-backend/test/setup-util.js
+++ b/project-tracker-backend/test/setup-util.js
@@ -28,45 +28,42 @@ exports.MockResponse = class MockResponse {
     }
 };
 
-exports.createRequestList = function(user_given, user_ns, manager_given, manager_sn) {
-    const USER_NAME = `${user_given}${user_ns}`;
-    const EXPECTED_MANAGER = `${manager_given} ${manager_sn}`;
-
-    const INVESTIGATOR_USER_ID = "INVESTIGATOR_USER_ID";
-    const PI_USER_ID = "PI_USER_ID";
-    const INVESTIGATOR_HIERARCHY_ID = "INVESTIGATOR_HIERARCHY_ID";
-    const PI_HIERARCHY_ID = "PI_HIERARCHY_ID";
+exports.createRequestList = function(email1, email2) {
+    const CURRENT_DATA_ACCESS_EMAIL = "CURRENT_DATA_ACCESS_EMAIL";
+    const CURRENT_QC_ACCESS_EMAIL = "CURRENT_QC_ACCESS_EMAIL";
+    const LEGACY_DATA_ACCESS_EMAIL = "LEGACY_DATA_ACCESS_EMAIL";
+    const LEGACY_QC_ACCESS_EMAIL = "LEGACY_QC_ACCESS_EMAIL";
 
     const requests = [
         {
-            "requestId": INVESTIGATOR_USER_ID,
-            "investigator": USER_NAME,
-            "pi": ""
+            "requestId": CURRENT_DATA_ACCESS_EMAIL,
+            "dataAccessEmails": `${email1},u1.mskcc.org`,
+            "qcAccessEmail": "",
         },
         {
-            "requestId": PI_USER_ID,
-            "investigator": "",
-            "pi": USER_NAME
+            "requestId": CURRENT_QC_ACCESS_EMAIL,
+            "dataAccessEmails": "",
+            "qcAccessEmail": `${email1},u1.mskcc.org`
         },
         {
-            "requestId": INVESTIGATOR_HIERARCHY_ID,
-            "investigator": EXPECTED_MANAGER,
-            "pi": ""
+            "requestId": LEGACY_DATA_ACCESS_EMAIL,
+            "dataAccessEmails": `${email2},u1.mskcc.org`,
+            "qcAccessEmail": ""
         },
         {
-            "requestId": PI_HIERARCHY_ID,
-            "investigator": "",
-            "pi": EXPECTED_MANAGER
-        },
-        {
-            "requestId": "NOT_RETURNED",
-            "investigator": "Rosalind Franklin",
-            "pi": ""
+            "requestId": LEGACY_QC_ACCESS_EMAIL,
+            "dataAccessEmails": "",
+            "qcAccessEmail": `${email2},u1.mskcc.org`
         },
         {
             "requestId": "NOT_RETURNED",
-            "investigator": "",
-            "pi": "Rosalind Franklin"
+            "dataAccessEmails": "Rosalind Franklin",
+            "qcAccessEmail": ""
+        },
+        {
+            "requestId": "NOT_RETURNED",
+            "dataAccessEmails": "",
+            "qcAccessEmail": "Rosalind Franklin"
         }
     ];
 

--- a/project-tracker-backend/test/test-lims-controller.js
+++ b/project-tracker-backend/test/test-lims-controller.js
@@ -29,12 +29,11 @@ describe("lims-controller", () => {
             // Clear cached response
             cache.del("GET_DELIVERED");
 
-            const GIVEN_USER = "user_given";
-            const SN_USER = "user_sn";
-            const GIVEN_MANAGER = "manager_given";
-            const SN_MANAGER = "manager_sn";
-
-            const requests = Object.assign({}, createRequestList(GIVEN_USER, SN_USER, GIVEN_MANAGER, SN_MANAGER));
+		    const CURRENT_USER="CURRENT_USER";
+		    const CURRENT_USER_EMAIL=`${CURRENT_USER}@mskcc.org`;
+		    const LEGACY_USER="LEGACY_USER";
+		    const LEGACY_USER_EMAIL=`R-LEGACY_USE@ski.mskcc.org`
+			const requests = Object.assign({}, createRequestList(CURRENT_USER_EMAIL, LEGACY_USER_EMAIL));
 
             // This sets the mock adapter on the default instance
             var mock = new MockAdapter(axios);
@@ -44,10 +43,7 @@ describe("lims-controller", () => {
             /* Performs filtering for requests w/ these representatives */
             validateJwtToken.returns({
                 "isUser": true,
-                "hierarchy": [
-                    { "sn": SN_USER, "givenName": GIVEN_USER },
-                    { "sn": SN_MANAGER, "givenName": GIVEN_MANAGER }
-                ]
+                "groups": `CN=${CURRENT_USER},CN=${LEGACY_USER}`
             });
 
             // We want to test the function that makes the backend request and filters projects
@@ -62,11 +58,11 @@ describe("lims-controller", () => {
             // Clear cached response
             cache.del("GET_DELIVERED");
 
-            const GIVEN_USER = "user_given";
-            const SN_USER = "user_sn";
-            const GIVEN_MANAGER = "manager_given";
-            const SN_MANAGER = "manager_sn";
-            const requests = Object.assign({}, createRequestList(GIVEN_USER, SN_USER, GIVEN_MANAGER, SN_MANAGER));
+		    const CURRENT_USER="CURRENT_USER";
+		    const CURRENT_USER_EMAIL=`${CURRENT_USER}@mskcc.org`;
+		    const LEGACY_USER="LEGACY_USER";
+		    const LEGACY_USER_EMAIL=`R-LEGACY_USE@ski.mskcc.org`
+			const requests = Object.assign({}, createRequestList(CURRENT_USER_EMAIL, LEGACY_USER_EMAIL));
 
             // This sets the mock adapter on the default instance
             var mock = new MockAdapter(axios);
@@ -77,10 +73,7 @@ describe("lims-controller", () => {
             /* Performs filtering for requests w/ these representatives */
             validateJwtToken.returns({
                 "isUser": false,
-                "hierarchy": [
-                    { "sn": SN_USER, "givenName": GIVEN_USER },
-                    { "sn": SN_MANAGER, "givenName": GIVEN_MANAGER }
-                ]
+                "groups": `CN=${CURRENT_USER},CN=${LEGACY_USER}`
             });
 
             // We want to test the function that makes the backend request and filters projects
@@ -98,11 +91,11 @@ describe("lims-controller", () => {
             // Clear cached response
             cache.del("GET_UNDELIVERED");
 
-            const GIVEN_USER = "user_given";
-            const SN_USER = "user_sn";
-            const GIVEN_MANAGER = "manager_given";
-            const SN_MANAGER = "manager_sn";
-            const requests = Object.assign({}, createRequestList(GIVEN_USER, SN_USER, GIVEN_MANAGER, SN_MANAGER));
+		    const CURRENT_USER="CURRENT_USER";
+		    const CURRENT_USER_EMAIL=`${CURRENT_USER}@mskcc.org`;
+		    const LEGACY_USER="LEGACY_USER";
+		    const LEGACY_USER_EMAIL=`R-LEGACY_USE@ski.mskcc.org`
+			const requests = Object.assign({}, createRequestList(CURRENT_USER_EMAIL, LEGACY_USER_EMAIL));
 
             // This sets the mock adapter on the default instance
             var mock = new MockAdapter(axios);
@@ -113,10 +106,7 @@ describe("lims-controller", () => {
             /* Performs filtering for requests w/ these representatives */
             validateJwtToken.returns({
                 "isUser": true,
-                "hierarchy": [
-                    { "sn": SN_USER, "givenName": GIVEN_USER },
-                    { "sn": SN_MANAGER, "givenName": GIVEN_MANAGER }
-                ]
+                "groups": `CN=${CURRENT_USER},CN=${LEGACY_USER}`
             });
 
             // We want to test the function that makes the backend request and filters projects
@@ -131,11 +121,11 @@ describe("lims-controller", () => {
             // Clear cached response
             cache.del("GET_UNDELIVERED");
 
-            const GIVEN_USER = "user_given";
-            const SN_USER = "user_sn";
-            const GIVEN_MANAGER = "manager_given";
-            const SN_MANAGER = "manager_sn";
-            const requests = Object.assign({}, createRequestList(GIVEN_USER, SN_USER, GIVEN_MANAGER, SN_MANAGER));
+		    const CURRENT_USER="CURRENT_USER";
+		    const CURRENT_USER_EMAIL=`${CURRENT_USER}@mskcc.org`;
+		    const LEGACY_USER="LEGACY_USER";
+		    const LEGACY_USER_EMAIL=`R-LEGACY_USE@ski.mskcc.org`
+			const requests = Object.assign({}, createRequestList(CURRENT_USER_EMAIL, LEGACY_USER_EMAIL));
 
             // This sets the mock adapter on the default instance
             var mock = new MockAdapter(axios);
@@ -145,10 +135,7 @@ describe("lims-controller", () => {
             /* Performs filtering for requests w/ these representatives */
             validateJwtToken.returns({
                 "isUser": false,
-                "hierarchy": [
-                    { "sn": SN_USER, "givenName": GIVEN_USER },
-                    { "sn": SN_MANAGER, "givenName": GIVEN_MANAGER }
-                ]
+                "groups": `CN=${CURRENT_USER},CN=${LEGACY_USER}`
             });
 
             // We want to test the function that makes the backend request and filters projects

--- a/project-tracker-backend/test/test-utility.js
+++ b/project-tracker-backend/test/test-utility.js
@@ -28,39 +28,33 @@ describe("utility", () => {
 	});
 
 	describe("filterProjectsOnHierarchy", () => {
-		it("should return projects filtered by hierarchy", async () => {
-			/**
-			 * Note - If this test fails, replace TEST_USER, USER_NAME, & EXPECTED_MANAGER w/ different users
-			 */
-
-			const SN_USER = "David";
-			const GIVEN_USER = "Streid";
-			const SN_MANAGER = "Lisa";
-			const GIVEN_MANAGER = "Wagner";
-
-			const { requests } = createRequestList(GIVEN_USER, SN_USER, GIVEN_MANAGER, SN_MANAGER);
+		it("should return CURRENT_USER & LEGACY_USER requests filtered by jwt token's user data", async () => {
+		    const CURRENT_USER="CURRENT_USER";
+		    const CURRENT_USER_EMAIL=`${CURRENT_USER}@mskcc.org`;
+		    const LEGACY_USER="LEGACY_USER";
+		    const LEGACY_USER_EMAIL=`R-LEGACY_USE@ski.mskcc.org`
+			const { requests } = createRequestList(CURRENT_USER_EMAIL, LEGACY_USER_EMAIL);
 
 			/* Performs filtering for requests w/ these representatives */
 			callback.returns({
-				"hierarchy": [
-					{ "sn": SN_USER, "givenName": GIVEN_USER },
-					{ "sn": SN_MANAGER, "givenName": GIVEN_MANAGER }
-				]
+				"groups": `CN=${CURRENT_USER},CN=${LEGACY_USER}`
 			});
 			// These four requestIDs should be returned, see @createRequestList
-			const INVESTIGATOR_USER_ID = "INVESTIGATOR_USER_ID";
-			const PI_USER_ID = "PI_USER_ID";
-			const INVESTIGATOR_HIERARCHY_ID = "INVESTIGATOR_HIERARCHY_ID";
-			const PI_HIERARCHY_ID = "PI_HIERARCHY_ID";
+			const CURRENT_DATA_ACCESS_EMAIL = "CURRENT_DATA_ACCESS_EMAIL";
+			const CURRENT_QC_ACCESS_EMAIL = "CURRENT_QC_ACCESS_EMAIL";
+			const LEGACY_DATA_ACCESS_EMAIL = "LEGACY_DATA_ACCESS_EMAIL";
+			const LEGACY_QC_ACCESS_EMAIL = "LEGACY_QC_ACCESS_EMAIL";
 
 			const filteredProjects = await filterProjectsOnHierarchy({}, requests);
 
-			const expectedFilteredIDs = new Set([ INVESTIGATOR_USER_ID, PI_USER_ID, INVESTIGATOR_HIERARCHY_ID, PI_HIERARCHY_ID ]);
+			const expectedFilteredIDs = new Set([ CURRENT_DATA_ACCESS_EMAIL, CURRENT_QC_ACCESS_EMAIL, LEGACY_DATA_ACCESS_EMAIL, LEGACY_QC_ACCESS_EMAIL ]);
 			const actualFilteredIDs = filteredProjects.map(p => p["requestId"]);
-			expect(filteredProjects.length).to.equal(expectedFilteredIDs.size);
+
 			for(const id of actualFilteredIDs){
+			    console.log(id);
 				expect(expectedFilteredIDs.has(id)).to.equal(true);
 			}
+			expect(filteredProjects.length).to.equal(expectedFilteredIDs.size);
 		});
 	});
 });


### PR DESCRIPTION
**Change**: UserSession's `userName` &  `groups` field determine the valid visibility groups that need to be present in either the `dataAccessEmails` or `qcAccessEmail`. This is different from before that determined the visibility groups from the user hierarchy and queried them against the `investigator` & `pi` fields of the request