### PR TITLE
Updated access emails + PI + Investigator

### DIFF
--- a/project-tracker-backend/helpers/utility.js
+++ b/project-tracker-backend/helpers/utility.js
@@ -103,8 +103,8 @@ const getSavedUserGroups = async (username) => {
 const getAccessGroups = (request) => {
 	const dataAccessEmailsValue = request["dataAccessEmails"] || "";
 	const qcAccessEmailsValue = request["qcAccessEmail"] || "";
-	const PIemail = request["PIemail"] || "";
-	const InvestigatorEmail = request["Investigatoremail"] || "";
+	const PIemail = request["pi"] || "";
+	const InvestigatorEmail = request["investigator"] || "";
 
 	const dataAccessEmails = dataAccessEmailsValue.split(",");
 	const qcAccessEmails = qcAccessEmailsValue.split(",");

--- a/project-tracker-backend/helpers/utility.js
+++ b/project-tracker-backend/helpers/utility.js
@@ -103,11 +103,13 @@ const getSavedUserGroups = async (username) => {
 const getAccessGroups = (request) => {
 	const dataAccessEmailsValue = request["dataAccessEmails"] || "";
 	const qcAccessEmailsValue = request["qcAccessEmail"] || "";
+	const PIemail = request["PIemail"] || "";
+	const InvestigatorEmail = request["Investigatoremail"] || "";
 
 	const dataAccessEmails = dataAccessEmailsValue.split(",");
 	const qcAccessEmails = qcAccessEmailsValue.split(",");
 
-	const accessEmails = dataAccessEmails.concat(qcAccessEmails);
+	const accessEmails = PIemail.concat(InvestigatorEmail).concat(dataAccessEmails).concat(qcAccessEmails);
 	const accessGroups = [];
 	const unrecognizedEmails = new Set();
 	for(const emailValue of accessEmails){

--- a/project-tracker-backend/helpers/utility.js
+++ b/project-tracker-backend/helpers/utility.js
@@ -103,9 +103,11 @@ const getSavedUserGroups = async (username) => {
 const getAccessGroups = (request) => {
 	const dataAccessEmailsValue = request["dataAccessEmails"] || "";
 	const qcAccessEmailsValue = request["qcAccessEmail"] || "";
-	const PIemail = request["pi"] || "";
-	const InvestigatorEmail = request["investigator"] || "";
+	const PIemail = request["piEmail"] || "";
+	const InvestigatorEmail = request["investigatorEmail"] || "";
 
+	console.log("PIemail: " + PIemail);
+	console.log("InvestigatorEmail: " + InvestigatorEmail);
 	const dataAccessEmails = dataAccessEmailsValue.split(",");
 	const qcAccessEmails = qcAccessEmailsValue.split(",");
 

--- a/project-tracker-frontend/src/components/common/header.js
+++ b/project-tracker-frontend/src/components/common/header.js
@@ -71,7 +71,7 @@ export function Header({ classes }) {
         const isLabMember = userSession['isLabMember'] || false;
         const isPM =  userSession['isPM'] || false;
         console.log(userName);
-        if (userName === 'fahimeh') return 'User';
+        if (userName === 'Fahimeh') return 'User';
         return isAdmin ? 'Admin' :
             isLabMember ? 'IGO' :
                 isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role

--- a/project-tracker-frontend/src/components/common/header.js
+++ b/project-tracker-frontend/src/components/common/header.js
@@ -70,10 +70,11 @@ export function Header({ classes }) {
         const isAdmin = userSession['isAdmin'] || false;
         const isLabMember = userSession['isLabMember'] || false;
         const isPM =  userSession['isPM'] || false;
-
-        return isAdmin ? 'Admin' :
-            isLabMember ? 'IGO' :
-                isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role
+        console.log(userName);
+        if (userName === 'fahimeh') return 'User';
+        // return isAdmin ? 'Admin' :
+        //     isLabMember ? 'IGO' :
+        //         isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role
     };
     const role = showUserView ? 'User' : getUserSessionRole();
 

--- a/project-tracker-frontend/src/components/common/header.js
+++ b/project-tracker-frontend/src/components/common/header.js
@@ -70,7 +70,6 @@ export function Header({ classes }) {
         const isAdmin = userSession['isAdmin'] || false;
         const isLabMember = userSession['isLabMember'] || false;
         const isPM =  userSession['isPM'] || false;
-        
         return isAdmin ? 'Admin' :
             isLabMember ? 'IGO' :
                 isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role

--- a/project-tracker-frontend/src/components/common/header.js
+++ b/project-tracker-frontend/src/components/common/header.js
@@ -70,8 +70,7 @@ export function Header({ classes }) {
         const isAdmin = userSession['isAdmin'] || false;
         const isLabMember = userSession['isLabMember'] || false;
         const isPM =  userSession['isPM'] || false;
-        console.log(userName);
-        if (userName === 'Fahimeh') return 'User';
+        
         return isAdmin ? 'Admin' :
             isLabMember ? 'IGO' :
                 isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role

--- a/project-tracker-frontend/src/components/common/header.js
+++ b/project-tracker-frontend/src/components/common/header.js
@@ -72,9 +72,9 @@ export function Header({ classes }) {
         const isPM =  userSession['isPM'] || false;
         console.log(userName);
         if (userName === 'fahimeh') return 'User';
-        // return isAdmin ? 'Admin' :
-        //     isLabMember ? 'IGO' :
-        //         isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role
+        return isAdmin ? 'Admin' :
+            isLabMember ? 'IGO' :
+                isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role
     };
     const role = showUserView ? 'User' : getUserSessionRole();
 

--- a/project-tracker-frontend/src/components/common/header.js
+++ b/project-tracker-frontend/src/components/common/header.js
@@ -70,6 +70,7 @@ export function Header({ classes }) {
         const isAdmin = userSession['isAdmin'] || false;
         const isLabMember = userSession['isLabMember'] || false;
         const isPM =  userSession['isPM'] || false;
+        
         return isAdmin ? 'Admin' :
             isLabMember ? 'IGO' :
                 isPM ? 'PM' : 'User';   // Everyone is a user if they don't have a special role

--- a/project-tracker-frontend/src/services/services.js
+++ b/project-tracker-frontend/src/services/services.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import {PROJECTS_ENDPOINT, LOGIN_PAGE_URL, HOME_PAGE_PATH, HOST} from "../config";
 import {getResponseData} from "../utils/utils";
 
-var start_date = 1514851261000; // Epochtime: Tuesday, January 2, 2018 12:01:01 AM
-var currect_date = Date.now();
-console.log("start_date = " + start_date);
-console.log("current_date = " + currect_date);
-var HISTORY_QUERY_LENGTH = Math.ceil((currect_date - start_date)/(1000 * 3600 * 24));
-console.log("days: " + HISTORY_QUERY_LENGTH);
+// var start_date = 1514851261000; // Epochtime: Tuesday, January 2, 2018 12:01:01 AM
+// var currect_date = Date.now();
+// console.log("start_date = " + start_date);
+// console.log("current_date = " + currect_date);
+var HISTORY_QUERY_LENGTH = 730; // Math.ceil((currect_date - start_date)/(1000 * 3600 * 24));
+//console.log("days: " + HISTORY_QUERY_LENGTH);
 
 export function getUserSession() {
     return axios

--- a/project-tracker-frontend/src/services/services.js
+++ b/project-tracker-frontend/src/services/services.js
@@ -2,7 +2,12 @@ import axios from 'axios';
 import {PROJECTS_ENDPOINT, LOGIN_PAGE_URL, HOME_PAGE_PATH, HOST} from "../config";
 import {getResponseData} from "../utils/utils";
 
-const HISTORY_QUERY_LENGTH = 600;  // Past 10 years...
+var start_date = 1514851261000; // Epochtime: Tuesday, January 2, 2018 12:01:01 AM
+var currect_date = Date.now();
+console.log("start_date = " + start_date);
+console.log("current_date = " + currect_date);
+var HISTORY_QUERY_LENGTH = Math.ceil((currect_date - start_date)/(1000 * 3600 * 24));
+console.log("days: " + HISTORY_QUERY_LENGTH);
 
 export function getUserSession() {
     return axios


### PR DESCRIPTION
The updates include:
- Access to request tracker by default granted to PI and investigator. 
- Querying project lists for the past 2 years (so long as samples) instead of the past 600 days.